### PR TITLE
remove EIC monte carlos

### DIFF
--- a/updatebuild.sh
+++ b/updatebuild.sh
@@ -103,27 +103,6 @@ else
 fi
 
 echo "--------------------------------------------------------"
-echo "Monte Carlos"
-echo "--------------------------------------------------------"
-
-md5_check ${URLBase}/MCEG.tar.bz2.md5 ${DownloadBase}/singularity/MCEG.tar.bz2.md5
-
-if [ $? != 0 ]; then
-    if [ -d ${DownloadBase}/${sysname}/MCEG ]; then
-        echo "deleting old Monte Carlos"
-	rm -rf ${DownloadBase}/${sysname}/MCEG
-    fi
-    echo "Downloading ${URLBase}/MCEG.tar.bz2 -> ${DownloadBase}/singularity/ ..."
-    curl -H 'Cache-Control: no-cache' -k ${URLBase}/MCEG.tar.bz2   | tar xjf -
-    curl -H 'Cache-Control: no-cache' -ks ${URLBase}/MCEG.tar.bz2.md5 > ${DownloadBase}/singularity/MCEG.tar.bz2.md5
-else
-    echo "${URLBase}/MCEG.tar.bz2 has not changed since the last download"
-    echo "- Its md5 sum is ${DownloadBase}/singularity/MCEG.tar.bz2.md5 : " `cat ${DownloadBase}/singularity/MCEG.tar.bz2.md5`
-fi
-
-
-
-echo "--------------------------------------------------------"
 echo "sPHENIX build images"
 echo "--------------------------------------------------------"
 


### PR DESCRIPTION
This PR removed the MCEG from the updatebuild script. The maintained version is now under the eic cvmfs area, while this one gets a copy of the mceg's installed under the sphenix cvmfs area. This will be removed just now. In the future users should use the updatebuild script from the eic singularity repo to fetch an up to date version. If it becomes necessary this can be reinstated but I doubt anyone uses them for sPHENIX