### PR TITLE
Add gcc-12.1.0 to sysname printout

### DIFF
--- a/updatebuild.sh
+++ b/updatebuild.sh
@@ -32,7 +32,7 @@ do
 	    shift # past argument=value
 	    ;;
 	--help|-h|*)
-	    echo "Usage: $0 [--build=<new>] [--sysname=<gcc-8.3|x8664_sl7>] [--source=URL] [--target=directory] [--clean]";
+	    echo "Usage: $0 [--build=<new>] [--sysname=<gcc-8.3|gcc-12.1.0|x8664_sl7>] [--source=URL] [--target=directory] [--clean]";
 	    exit;
 	    shift # past argument with no value
 	    ;;


### PR DESCRIPTION
We now have nightly gcc 12 tar balls, add gcc-12.1.0 to sysname help printout (default is still gcc-8.3)